### PR TITLE
Fix: Use user-configured pinned_id instead of array index

### DIFF
--- a/examples/climate_timer_example.yaml
+++ b/examples/climate_timer_example.yaml
@@ -1,0 +1,25 @@
+# This turns off a climate entity when its associated timer expires
+# The timers have an id starting with the name of the climate entity
+# ie, "study_1hr".
+# This assumes that we're using a mqtt source for the timer
+
+- alias: "Climate Timer - Turn Off Climate When Timer Expires"
+  description: "Turn off climate entity when its associated timer expires"
+  id: timer_turn_off_climate
+  trigger:
+    - platform: mqtt
+      topic: "simple_timer_card/events/expired"
+  action:
+    - action: climate.turn_off
+      target:
+        entity_id: >
+          {% set pinned_id = trigger.payload_json.pinned_id %}
+          {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
+          {{ 'climate.' ~ entity_name }}
+  condition:
+    - condition: template
+      value_template: >
+        {% set pinned_id = trigger.payload_json.pinned_id %}
+        {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
+        {% set entity_id = 'climate.' ~ entity_name %}
+        {{ entity_id in states }}

--- a/examples/climate_timer_example.yaml
+++ b/examples/climate_timer_example.yaml
@@ -1,6 +1,6 @@
 # This turns off a climate entity when its associated timer expires
 # The timers have an id starting with the name of the climate entity
-# ie, "study_1hr".
+# ie, "study_1hr". Fallback to parsing the name if a pinned id is not present.
 # This assumes that we're using a mqtt source for the timer
 
 - alias: "Climate Timer - Turn Off Climate When Timer Expires"
@@ -9,17 +9,19 @@
   trigger:
     - platform: mqtt
       topic: "simple_timer_card/events/expired"
+      value_template: " {{ trigger.payload_json.get('pinned_id') | regex_search('_.*$') }} "
   action:
     - action: climate.turn_off
       target:
         entity_id: >
-          {% set pinned_id = trigger.payload_json.pinned_id %}
-          {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
-          {{ 'climate.' ~ entity_name }}
-  condition:
-    - condition: template
-      value_template: >
-        {% set pinned_id = trigger.payload_json.pinned_id %}
-        {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
-        {% set entity_id = 'climate.' ~ entity_name %}
-        {{ entity_id in states }}
+          {% set pinned_id = trigger.payload_json.get('pinned_id', '') %}
+          {% if pinned_id and pinned_id is string and pinned_id | regex_search('_.*$') %}
+            {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
+            {% set entity_id = 'climate.' ~ entity_name %}
+            {{ entity_id }}
+          {% else %}
+            {% set label = trigger.payload_json.get('label', '') %}
+            {% set entity_name = label | regex_replace(' \\d.*$', '') | trim %}
+            {% set entity_id = 'climate.' ~ entity_name | lower() | replace(' ', '_') %}
+            {{ entity_id }}
+          {% endif %}

--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -2716,7 +2716,7 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
       const now = Date.now();
       return {
         id: `pinned-${idx}`,
-        pinned_id: `pinned-${idx}`,
+        pinned_id: (p && typeof p === "object" && p.id) ? p.id : `pinned-${idx}`,
         kind: "template",
         name: label,
         label,


### PR DESCRIPTION
## Summary

The `_getPinnedTimers()` function was setting `pinned_id` to the array index (`pinned-${idx}`) instead of using the user-configured `id` field from the pinned timer configuration.

## Problem

When users configure pinned timers with an `id` field (e.g., `id: study_1h`), that ID was not preserved in the `pinned_id` field. Instead, the code was using the array index (e.g., `pinned-0`), making it impossible to reliably identify which timer triggered an event via MQTT.

## Solution

Modified the `_getPinnedTimers()` function to use the user-configured `id` field when available, falling back to the array index only if no `id` is provided.

### Before

```javascript
pinned_id: `pinned-${idx}`,
```

### After

```javascript
pinned_id: (p && typeof p === "object" && p.id) ? p.id : `pinned-${idx}`,
```

## Impact

This fix ensures that:

- User-configured timer IDs are preserved in MQTT events
- Automations can reliably identify which timer triggered an event
- The `pinned_id` field in MQTT payloads now contains the expected user-configured value

## Example

### Dashboard Configuration

```yaml
pinned_timers:
  - id: study_1h
    name: Study 1 Hour
    duration: 1h
```

### MQTT Event (After Fix)

```json
{
  "id": "custom-1737636400000",
  "pinned_id": "study_1h", // Now correctly uses user-configured ID
  "label": "Study 1 Hour",
  "event": "expired"
}
```

### Automation

```yaml
action:
  - action: climate.turn_off
    target:
      entity_id: >
        {% set pinned_id = trigger.payload_json.pinned_id %}
        {% set entity_name = pinned_id | regex_replace('_.+$', '') %}
        {{ 'climate.' ~ entity_name }}
```

## Related Issues

This fix enables use of `pinned_id` prefix-based identification for HVAC timer automations, as described in related documentation.
