### PR TITLE
ci: attach built simple-timer-card.js to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+﻿name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  upload:
+    name: Build and attach asset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload card asset to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: simple-timer-card.js


### PR DESCRIPTION
Adds a release workflow that runs \
pm install && npm run build\ on release.published events and uploads \simple-timer-card.js\ as a release asset.

This lets HACS surface a download count for the card (the HACS UI reads \download_count\ from the release asset matching \hacs.json:filename\), and ensures the published asset always matches the tagged source.

The v2.2.4 release was backfilled separately by uploading the locally built bundle.