### PR TITLE
feat: add Hebrew (he) translation with RTL support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -22,6 +22,7 @@ The card supports multiple UI languages:
 * Danish (`da`)
 * Italian (`it`)
 * French (`fr`)
+* Hebrew (`he`) - right-to-left
 
 ```yaml
 language: de

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ No dashboards clutter. No duplicated cards. Just timers.
 * **Persistent storage**: Local or MQTT based, survives reloads and syncs across devices
 * **Audio & expiry actions**: Optional sounds, snooze, auto dismiss, and expiry behavior
 * **Theme aware**: Automatically matches your Home Assistant theme
-* **🌍 Multi-language support**: English, German, Spanish, Danish, Italian, and French
+* **🌍 Multi-language support**: English, German, Spanish, Danish, Italian, French, and Hebrew (RTL)
 * **[Spook](https://spook.boo/) fallback**: Automatically falls back to Spook's `timer.set_duration` for non-admin users
 
 ---

--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -36,7 +36,7 @@ const t=globalThis,i$1=t=>t,s$1=t.trustedTypes,e=s$1?s$1.createPolicy("lit-html"
  */
 
 
-const cardVersion="2.2.4";
+const cardVersion="2.3.0";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -253,6 +253,35 @@ const TRANSLATIONS = {
     month: "mois", months: "mois", year: "année", years: "années",
     hour: "heure", hours: "heures", minute: "minute", minutes: "minutes",
     second: "seconde", seconds: "secondes",
+  },
+  he: {
+    no_timers: "אין טיימרים",
+    click_to_start: "לחץ להתחלה",
+    no_active_timers: "אין טיימרים פעילים",
+    active_timers: "טיימרים פעילים",
+    add: "הוסף",
+    custom: "מותאם אישית",
+    cancel: "ביטול",
+    save: "שמור",
+    start: "התחל",
+    snooze: "נודניק",
+    dismiss: "סגור",
+    ready: "מוכן",
+    paused: "מושהה",
+    times_up: "הזמן נגמר!",
+    timer: "טיימר",
+    hour_ago: "לפני {n} שעה",
+    hours_ago: "לפני {n} שעות",
+    minute_ago: "לפני {n} דקה",
+    minutes_ago: "לפני {n} דקות",
+    second_ago: "לפני {n} שנייה",
+    seconds_ago: "לפני {n} שניות",
+    h: "ש'", m: "ד'", s: "שנ'", d: "י'",
+    w_short: "שב'", mo_short: "חו'", y_short: "שנה",
+    day: "יום", days: "ימים", week: "שבוע", weeks: "שבועות",
+    month: "חודש", months: "חודשים", year: "שנה", years: "שנים",
+    hour: "שעה", hours: "שעות", minute: "דקה", minutes: "דקות",
+    second: "שנייה", seconds: "שניות",
   }
 };
 
@@ -291,6 +320,12 @@ class SimpleTimerCard extends i {
     const raw = this._config?.language || this.hass?.language || "en";
     const lang = String(raw).toLowerCase().split(/[-_]/)[0];
     return TRANSLATIONS[lang]?.[key] || TRANSLATIONS["en"][key] || key;
+  }
+
+  _isRTL() {
+    const raw = this._config?.language || this.hass?.language || "en";
+    const lang = String(raw).toLowerCase().split(/[-_]/)[0];
+    return lang === "he" || lang === "ar" || lang === "fa" || lang === "ur";
   }
 
   _validateAudioUrl(url) {
@@ -3397,7 +3432,7 @@ const layout = this._config.layout;
       </div>
     `;
     return b`
-      <ha-card>
+      <ha-card dir=${this._isRTL() ? "rtl" : "ltr"}>
         ${this._config.title ? b`<div class="card-header"><span>${this._config.title}</span></div>` : ""}
         ${timers.length === 0 ? b`<div class="grid"><div>${noTimerCard}</div></div>` : b`<div class="grid"><div>${activeCard}</div></div>`}
       </ha-card>
@@ -3466,7 +3501,7 @@ const layout = this._config.layout;
       .vgrid.cols-2 { grid-template-columns: 1fr 1fr; }
       .vtile { position: relative; min-height: 120px; display: flex; align-items: center; justify-content: center; box-sizing: border-box; }
       .vtile .vcol { z-index: 1; width: 100%; display: flex; flex-direction: column; align-items: center; gap: 4px; text-align: center; }
-      .vtile-close { position: absolute; top: 4px; right: 4px; border: 0; background: none; padding: 4px; border-radius: 50%; color: var(--secondary-text-color); cursor: pointer; z-index: 3; }
+      .vtile-close { position: absolute; top: 4px; inset-inline-end: 4px; border: 0; background: none; padding: 4px; border-radius: 50%; color: var(--secondary-text-color); cursor: pointer; z-index: 3; }
       .vtile-close:hover { background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
       .icon-wrap.large { width: 36px; height: 36px; flex: 0 0 36px; border-radius: var(--ha-card-border-radius, 50%); background: color-mix(in srgb, var(--tcolor, var(--primary-color)) 18%, var(--ha-card-background, var(--card-background-color))); display: flex; align-items: center; justify-content: center; }
       .vtitle { font-size: 14px; font-weight: 600; line-height: 16px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin: 0; }
@@ -3977,13 +4012,14 @@ _pinnedTimerValueChanged(ev, index) {
           <mwc-list-item value="milestones">Milestones (bar styles only)</mwc-list-item>
         </ha-select>
 
-        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
+        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
           <mwc-list-item value="en">English</mwc-list-item>
           <mwc-list-item value="de">Deutsch</mwc-list-item>
           <mwc-list-item value="es">Español</mwc-list-item>
 		      <mwc-list-item value="da">Dansk</mwc-list-item>
 		      <mwc-list-item value="it">Italiano</mwc-list-item>
           <mwc-list-item value="fr">Français</mwc-list-item>
+          <mwc-list-item value="he">עברית</mwc-list-item>
         </ha-select>
       </div>
     `;
@@ -4395,9 +4431,9 @@ const storageContent = b`
 
       .entity-editor { border: 1px solid var(--divider-color); border-radius: 8px; padding: 12px; position: relative; }
       .entity-options { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
-      .remove-entity { position: absolute; top: 6px; right: 6px; background: var(--error-color, #f44336); border: none; border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: white; }
+      .remove-entity { position: absolute; top: 6px; inset-inline-end: 6px; background: var(--error-color, #f44336); border: none; border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: white; }
 
-      .helper-text { font-size: 11px; color: var(--secondary-text-color); margin-top: 4px; margin-left: 4px; }
+      .helper-text { font-size: 11px; color: var(--secondary-text-color); margin-top: 4px; margin-inline-start: 4px; }
     `;
   }
 }

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -11,7 +11,7 @@
 
 import { html, LitElement, css } from "lit";
 
-const cardVersion="2.2.4";
+const cardVersion="2.3.0";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -228,6 +228,35 @@ const TRANSLATIONS = {
     month: "mois", months: "mois", year: "année", years: "années",
     hour: "heure", hours: "heures", minute: "minute", minutes: "minutes",
     second: "seconde", seconds: "secondes",
+  },
+  he: {
+    no_timers: "אין טיימרים",
+    click_to_start: "לחץ להתחלה",
+    no_active_timers: "אין טיימרים פעילים",
+    active_timers: "טיימרים פעילים",
+    add: "הוסף",
+    custom: "מותאם אישית",
+    cancel: "ביטול",
+    save: "שמור",
+    start: "התחל",
+    snooze: "נודניק",
+    dismiss: "סגור",
+    ready: "מוכן",
+    paused: "מושהה",
+    times_up: "הזמן נגמר!",
+    timer: "טיימר",
+    hour_ago: "לפני {n} שעה",
+    hours_ago: "לפני {n} שעות",
+    minute_ago: "לפני {n} דקה",
+    minutes_ago: "לפני {n} דקות",
+    second_ago: "לפני {n} שנייה",
+    seconds_ago: "לפני {n} שניות",
+    h: "ש'", m: "ד'", s: "שנ'", d: "י'",
+    w_short: "שב'", mo_short: "חו'", y_short: "שנה",
+    day: "יום", days: "ימים", week: "שבוע", weeks: "שבועות",
+    month: "חודש", months: "חודשים", year: "שנה", years: "שנים",
+    hour: "שעה", hours: "שעות", minute: "דקה", minutes: "דקות",
+    second: "שנייה", seconds: "שניות",
   }
 };
 
@@ -266,6 +295,12 @@ class SimpleTimerCard extends LitElement {
     const raw = this._config?.language || this.hass?.language || "en";
     const lang = String(raw).toLowerCase().split(/[-_]/)[0];
     return TRANSLATIONS[lang]?.[key] || TRANSLATIONS["en"][key] || key;
+  }
+
+  _isRTL() {
+    const raw = this._config?.language || this.hass?.language || "en";
+    const lang = String(raw).toLowerCase().split(/[-_]/)[0];
+    return lang === "he" || lang === "ar" || lang === "fa" || lang === "ur";
   }
 
   _validateAudioUrl(url) {
@@ -3372,7 +3407,7 @@ const layout = this._config.layout;
       </div>
     `;
     return html`
-      <ha-card>
+      <ha-card dir=${this._isRTL() ? "rtl" : "ltr"}>
         ${this._config.title ? html`<div class="card-header"><span>${this._config.title}</span></div>` : ""}
         ${timers.length === 0 ? html`<div class="grid"><div>${noTimerCard}</div></div>` : html`<div class="grid"><div>${activeCard}</div></div>`}
       </ha-card>
@@ -3441,7 +3476,7 @@ const layout = this._config.layout;
       .vgrid.cols-2 { grid-template-columns: 1fr 1fr; }
       .vtile { position: relative; min-height: 120px; display: flex; align-items: center; justify-content: center; box-sizing: border-box; }
       .vtile .vcol { z-index: 1; width: 100%; display: flex; flex-direction: column; align-items: center; gap: 4px; text-align: center; }
-      .vtile-close { position: absolute; top: 4px; right: 4px; border: 0; background: none; padding: 4px; border-radius: 50%; color: var(--secondary-text-color); cursor: pointer; z-index: 3; }
+      .vtile-close { position: absolute; top: 4px; inset-inline-end: 4px; border: 0; background: none; padding: 4px; border-radius: 50%; color: var(--secondary-text-color); cursor: pointer; z-index: 3; }
       .vtile-close:hover { background: color-mix(in srgb, var(--primary-color) 10%, transparent); }
       .icon-wrap.large { width: 36px; height: 36px; flex: 0 0 36px; border-radius: var(--ha-card-border-radius, 50%); background: color-mix(in srgb, var(--tcolor, var(--primary-color)) 18%, var(--ha-card-background, var(--card-background-color))); display: flex; align-items: center; justify-content: center; }
       .vtitle { font-size: 14px; font-weight: 600; line-height: 16px; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin: 0; }
@@ -3952,13 +3987,14 @@ _pinnedTimerValueChanged(ev, index) {
           <mwc-list-item value="milestones">Milestones (bar styles only)</mwc-list-item>
         </ha-select>
 
-        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
+        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
           <mwc-list-item value="en">English</mwc-list-item>
           <mwc-list-item value="de">Deutsch</mwc-list-item>
           <mwc-list-item value="es">Español</mwc-list-item>
 		      <mwc-list-item value="da">Dansk</mwc-list-item>
 		      <mwc-list-item value="it">Italiano</mwc-list-item>
           <mwc-list-item value="fr">Français</mwc-list-item>
+          <mwc-list-item value="he">עברית</mwc-list-item>
         </ha-select>
       </div>
     `;
@@ -4370,9 +4406,9 @@ const storageContent = html`
 
       .entity-editor { border: 1px solid var(--divider-color); border-radius: 8px; padding: 12px; position: relative; }
       .entity-options { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; }
-      .remove-entity { position: absolute; top: 6px; right: 6px; background: var(--error-color, #f44336); border: none; border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: white; }
+      .remove-entity { position: absolute; top: 6px; inset-inline-end: 6px; background: var(--error-color, #f44336); border: none; border-radius: 50%; width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; cursor: pointer; color: white; }
 
-      .helper-text { font-size: 11px; color: var(--secondary-text-color); margin-top: 4px; margin-left: 4px; }
+      .helper-text { font-size: 11px; color: var(--secondary-text-color); margin-top: 4px; margin-inline-start: 4px; }
     `;
   }
 }


### PR DESCRIPTION
Adds Hebrew as the seventh supported UI language and introduces RTL handling so the card layout flips correctly when the user picks Hebrew (or another RTL language).

## Changes

- **TRANSLATIONS**: Full Hebrew strings for every key, including templated time-ago strings (לפני {n} שעה).
- **Visual editor**: Added Hebrew option to the Language dropdown.
- **RTL support**: New _isRTL() helper. The <ha-card> root now sets dir="rtl" when the active language is he, ar, fa, or ur.
- **Logical CSS**: Switched .vtile-close, .remove-entity, and .helper-text to use inset-inline-end / margin-inline-start so they mirror with the direction.
- **Docs**: README.md and CONFIGURATION.md updated.
- **Version**: cardVersion bumped to 2.3.0.

## Notes

The progress fill (.progress-fill) was already direction-safe via inset: 6px 0; width: 0 (when the inline axis flips, an absolutely-positioned box with no explicit anchor uses the start side, which is right in RTL).

Non-RTL languages get an explicit dir="ltr" on the card so behavior remains deterministic regardless of the surrounding HA direction.