### PR TITLE
feat: add Polish (pl) translation

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -23,6 +23,7 @@ The card supports multiple UI languages:
 * Italian (`it`)
 * French (`fr`)
 * Hebrew (`he`) - right-to-left
+* Polish (`pl`)
 
 ```yaml
 language: de

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ No dashboards clutter. No duplicated cards. Just timers.
 * **Persistent storage**: Local or MQTT based, survives reloads and syncs across devices
 * **Audio & expiry actions**: Optional sounds, snooze, auto dismiss, and expiry behavior
 * **Theme aware**: Automatically matches your Home Assistant theme
-* **🌍 Multi-language support**: English, German, Spanish, Danish, Italian, French, and Hebrew (RTL)
+* **🌍 Multi-language support**: English, German, Spanish, Danish, Italian, French, Hebrew (RTL), and Polish
 * **[Spook](https://spook.boo/) fallback**: Automatically falls back to Spook's `timer.set_duration` for non-admin users
 
 ---

--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -282,6 +282,35 @@ const TRANSLATIONS = {
     month: "חודש", months: "חודשים", year: "שנה", years: "שנים",
     hour: "שעה", hours: "שעות", minute: "דקה", minutes: "דקות",
     second: "שנייה", seconds: "שניות",
+  },
+  pl: {
+    no_timers: "Brak minutników",
+    click_to_start: "Kliknij, aby uruchomić",
+    no_active_timers: "Brak aktywnych minutników",
+    active_timers: "Aktywne minutniki",
+    add: "Dodaj",
+    custom: "Niestandardowy",
+    cancel: "Anuluj",
+    save: "Zapisz",
+    start: "Uruchom",
+    snooze: "Drzemka",
+    dismiss: "Odrzuć",
+    ready: "Gotowy",
+    paused: "Wstrzymany",
+    times_up: "Czas minął!",
+    timer: "Minutnik",
+    hour_ago: "{n} godzinę temu",
+    hours_ago: "{n} godzin temu",
+    minute_ago: "{n} minutę temu",
+    minutes_ago: "{n} minut temu",
+    second_ago: "{n} sekundę temu",
+    seconds_ago: "{n} sekund temu",
+    h: "h", m: "m", s: "s", d: "d",
+    w_short: "tyg", mo_short: "mies", y_short: "r",
+    day: "dzień", days: "dni", week: "tydzień", weeks: "tygodni",
+    month: "miesiąc", months: "miesięcy", year: "rok", years: "lat",
+    hour: "godzina", hours: "godzin", minute: "minuta", minutes: "minut",
+    second: "sekunda", seconds: "sekund",
   }
 };
 
@@ -4012,7 +4041,7 @@ _pinnedTimerValueChanged(ev, index) {
           <mwc-list-item value="milestones">Milestones (bar styles only)</mwc-list-item>
         </ha-select>
 
-        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
+        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"},{value:"pl",label:"Polski"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
           <mwc-list-item value="en">English</mwc-list-item>
           <mwc-list-item value="de">Deutsch</mwc-list-item>
           <mwc-list-item value="es">Español</mwc-list-item>
@@ -4020,6 +4049,7 @@ _pinnedTimerValueChanged(ev, index) {
 		      <mwc-list-item value="it">Italiano</mwc-list-item>
           <mwc-list-item value="fr">Français</mwc-list-item>
           <mwc-list-item value="he">עברית</mwc-list-item>
+          <mwc-list-item value="pl">Polski</mwc-list-item>
         </ha-select>
       </div>
     `;

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -257,6 +257,35 @@ const TRANSLATIONS = {
     month: "חודש", months: "חודשים", year: "שנה", years: "שנים",
     hour: "שעה", hours: "שעות", minute: "דקה", minutes: "דקות",
     second: "שנייה", seconds: "שניות",
+  },
+  pl: {
+    no_timers: "Brak minutników",
+    click_to_start: "Kliknij, aby uruchomić",
+    no_active_timers: "Brak aktywnych minutników",
+    active_timers: "Aktywne minutniki",
+    add: "Dodaj",
+    custom: "Niestandardowy",
+    cancel: "Anuluj",
+    save: "Zapisz",
+    start: "Uruchom",
+    snooze: "Drzemka",
+    dismiss: "Odrzuć",
+    ready: "Gotowy",
+    paused: "Wstrzymany",
+    times_up: "Czas minął!",
+    timer: "Minutnik",
+    hour_ago: "{n} godzinę temu",
+    hours_ago: "{n} godzin temu",
+    minute_ago: "{n} minutę temu",
+    minutes_ago: "{n} minut temu",
+    second_ago: "{n} sekundę temu",
+    seconds_ago: "{n} sekund temu",
+    h: "h", m: "m", s: "s", d: "d",
+    w_short: "tyg", mo_short: "mies", y_short: "r",
+    day: "dzień", days: "dni", week: "tydzień", weeks: "tygodni",
+    month: "miesiąc", months: "miesięcy", year: "rok", years: "lat",
+    hour: "godzina", hours: "godzin", minute: "minuta", minutes: "minut",
+    second: "sekunda", seconds: "sekund",
   }
 };
 
@@ -3987,7 +4016,7 @@ _pinnedTimerValueChanged(ev, index) {
           <mwc-list-item value="milestones">Milestones (bar styles only)</mwc-list-item>
         </ha-select>
 
-        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
+        <ha-select label="Language" .value=${(String(this._config.language || this.hass?.language || "en").toLowerCase().split(/[-_]/)[0])} .configValue=${"language"} .options=${[{value:"en",label:"English"},{value:"de",label:"Deutsch"},{value:"es",label:"Español"},{value:"da",label:"Dansk"},{value:"it",label:"Italiano"},{value:"fr",label:"Français"},{value:"he",label:"עברית"},{value:"pl",label:"Polski"}]} @selected=${this._selectChanged} @closed=${(e) => e.stopPropagation()}>
           <mwc-list-item value="en">English</mwc-list-item>
           <mwc-list-item value="de">Deutsch</mwc-list-item>
           <mwc-list-item value="es">Español</mwc-list-item>
@@ -3995,6 +4024,7 @@ _pinnedTimerValueChanged(ev, index) {
 		      <mwc-list-item value="it">Italiano</mwc-list-item>
           <mwc-list-item value="fr">Français</mwc-list-item>
           <mwc-list-item value="he">עברית</mwc-list-item>
+          <mwc-list-item value="pl">Polski</mwc-list-item>
         </ha-select>
       </div>
     `;


### PR DESCRIPTION
Adds Polish translations to the card and the visual editor's language picker.

## Notes

- The _ago time-ago strings use Polish accusative-singular for n=1 ({n} godzinę temu) and genitive-plural for n>1 ({n} godzin temu). Polish has a third plural form for 2-4 (godziny) that the current data shape does not have a slot for; using the genitive plural for all n>1 is the conventional fallback in apps with a binary singular/plural model.
- README.md and CONFIGURATION.md updated.
- This is a follow-up to #92; it does NOT bump the version since v2.3.0 has not been published yet.