### PR TITLE
fix: isolate storage namespace per card instance (#94)

### DIFF
--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -512,7 +512,14 @@ class SimpleTimerCard extends i {
     const style = validStyles.includes((config.style || "").toLowerCase()) ? (config.style || "").toLowerCase() : "bar_horizontal";
     const progressModeOptions = ["drain", "fill", "milestones"];
     const progressMode = progressModeOptions.includes(config.progress_mode) ? config.progress_mode : "drain";
-    this._storageNamespace = config.storage_namespace || config.default_timer_entity || "default";
+    const firstEntityFromList = Array.isArray(config.entities) && config.entities.length
+      ? (typeof config.entities[0] === "string" ? config.entities[0] : config.entities[0]?.entity)
+      : null;
+    this._storageNamespace =
+      config.storage_namespace ||
+      config.default_timer_entity ||
+      firstEntityFromList ||
+      `instance-${this._cardInstanceKey}`;
     const defaultUnits = ["days", "hours", "minutes", "seconds"];
     let timeUnits = defaultUnits;
     if (Array.isArray(config.time_format_units)) {

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -487,7 +487,14 @@ class SimpleTimerCard extends LitElement {
     const style = validStyles.includes((config.style || "").toLowerCase()) ? (config.style || "").toLowerCase() : "bar_horizontal";
     const progressModeOptions = ["drain", "fill", "milestones"];
     const progressMode = progressModeOptions.includes(config.progress_mode) ? config.progress_mode : "drain";
-    this._storageNamespace = config.storage_namespace || config.default_timer_entity || "default";
+    const firstEntityFromList = Array.isArray(config.entities) && config.entities.length
+      ? (typeof config.entities[0] === "string" ? config.entities[0] : config.entities[0]?.entity)
+      : null;
+    this._storageNamespace =
+      config.storage_namespace ||
+      config.default_timer_entity ||
+      firstEntityFromList ||
+      `instance-${this._cardInstanceKey}`;
     const defaultUnits = ["days", "hours", "minutes", "seconds"];
     let timeUnits = defaultUnits;
     if (Array.isArray(config.time_format_units)) {


### PR DESCRIPTION
## Summary
Fixes #94 — two `simple-timer-card` instances on the same view incorrectly mirror each other's state (preset timers added in one show up in the other).

## Root cause
`_storageNamespace` is used to derive the per‑card `localStorage` key (`simple-timer-card-${namespace}`). It was computed as:

```js
this._storageNamespace = config.storage_namespace || config.default_timer_entity || "default";
```

When neither `storage_namespace` nor `default_timer_entity` is configured, **both cards** fall back to `"default"`, so they read/write the same `simple-timer-card-default` key — anything one card creates (preset timers, custom timers) immediately appears in the other.

The reporter's config in #94 has neither option set on either card, so both end up sharing `simple-timer-card-default`.

## Fix
Add two more fallbacks before the literal `"default"` string is ever used:

1. First entity from the `entities:` list (matches the natural mental model: a card "about" `timer.foo` should namespace by `timer.foo`).
2. A per‑instance random key (`instance-${this._cardInstanceKey}`) so two unconfigured cards never collide.

```js
const firstEntityFromList = Array.isArray(config.entities) && config.entities.length
  ? (typeof config.entities[0] === "string" ? config.entities[0] : config.entities[0]?.entity)
  : null;
this._storageNamespace =
  config.storage_namespace ||
  config.default_timer_entity ||
  firstEntityFromList ||
  `instance-${this._cardInstanceKey}`;
```

`_cardInstanceKey` is already generated once per element in the constructor, so it's stable across re-renders of the same card but unique between instances.

## Backwards compatibility
- Cards that set `storage_namespace` or `default_timer_entity` are unaffected (same value as before).
- Cards that don't set either but **do** set `entities:` will now namespace by the first entity. Previously stored state under `simple-timer-card-default` won't be migrated, but those users were already experiencing the bleed bug; their state was effectively shared/unsafe.
- Cards with no `entities`, no `default_timer_entity`, and no `storage_namespace` will get a fresh per-session namespace. This is the only case where prior `default`-keyed state becomes inaccessible — acceptable since that state was unreliable by design.

## Files
- `src/simple-timer-card.js` — source change
- `simple-timer-card.js` — bundled output regenerated with the same fix so the change is live for HACS users immediately

## Testing
Manual reproduction with two cards on one view, no `storage_namespace` / `default_timer_entity` / `entities` configured:
- Before: adding a preset timer in card A shows it in card B.
- After: each card writes to its own `simple-timer-card-instance-<key>` and remains isolated.
