### PR TITLE
fix(editor): accept s/m/h/d suffixes for timer_presets input

### DIFF
--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -49,7 +49,7 @@ const a=Symbol.for(""),o$1=t=>{if(t?.r===a)return t?._$litStatic$},i=(t,...r)=>(
  */
 
 
-const cardVersion="2.4.1";
+const cardVersion="2.4.2";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -3678,13 +3678,11 @@ class SimpleTimerCardEditor extends i$1 {
     let value = hasChecked ? target.checked : target.value;
     if (key === "timer_presets" && typeof value === "string") {
       value = value.split(",").map(v => v.trim()).filter(v => v).map(v => {
-        if (v.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(v.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-        }
-        const minutes = parseInt(v, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = v.toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter(v => v !== null);
       if (value.length === 0) value = [5, 15, 30];
     }
@@ -4337,7 +4335,7 @@ _pinnedTimerValueChanged(ev, index) {
       </label>
 
       ${this._config.show_timer_presets !== false ? b`
-        ${this._tf({ label: "Timer presets", helper: "Minutes or seconds, e.g. 5, 15, 90s", value: (this._config.timer_presets || [5, 15, 30]).join(", "), configValue: "timer_presets", change: this._valueChanged })}
+        ${this._tf({ label: "Timer presets", helper: "Seconds, minutes, hours, or days. e.g. 5, 15, 90s, 2h", value: (this._config.timer_presets || [5, 15, 30]).join(", "), configValue: "timer_presets", change: this._valueChanged })}
         ${this._tf({ label: "Timer name presets", helper: "Comma-separated labels shown in the custom-name picker", value: (this._config.timer_name_presets || []).join(", "), configValue: "timer_name_presets", change: this._valueChanged })}
       ` : ""}
 

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -13,7 +13,7 @@ import { html, LitElement, css } from "lit";
 import { html as shtml, literal } from "lit/static-html.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-const cardVersion="2.4.1";
+const cardVersion="2.4.2";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -3642,13 +3642,11 @@ class SimpleTimerCardEditor extends LitElement {
     let value = hasChecked ? target.checked : target.value;
     if (key === "timer_presets" && typeof value === "string") {
       value = value.split(",").map(v => v.trim()).filter(v => v).map(v => {
-        if (v.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(v.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-        }
-        const minutes = parseInt(v, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = v.toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter(v => v !== null);
       if (value.length === 0) value = [5, 15, 30];
     }
@@ -4301,7 +4299,7 @@ _pinnedTimerValueChanged(ev, index) {
       </label>
 
       ${this._config.show_timer_presets !== false ? html`
-        ${this._tf({ label: "Timer presets", helper: "Minutes or seconds, e.g. 5, 15, 90s", value: (this._config.timer_presets || [5, 15, 30]).join(", "), configValue: "timer_presets", change: this._valueChanged })}
+        ${this._tf({ label: "Timer presets", helper: "Seconds, minutes, hours, or days. e.g. 5, 15, 90s, 2h", value: (this._config.timer_presets || [5, 15, 30]).join(", "), configValue: "timer_presets", change: this._valueChanged })}
         ${this._tf({ label: "Timer name presets", helper: "Comma-separated labels shown in the custom-name picker", value: (this._config.timer_name_presets || []).join(", "), configValue: "timer_name_presets", change: this._valueChanged })}
       ` : ""}
 


### PR DESCRIPTION
Closes #102.

## Summary

The editors `_valueChanged` handler for `timer_presets` only recognized the `s` suffix. `h`/`d`/`m` were silently stripped by `parseInt`, so typing `5h` coerced to the number `5` (5 minutes), and a list like `5h, 15h, 30h` produced no visible YAML or preview change because it matched the default `[5, 15, 30]`.

v2.4.1s `_formatPresetLabel` made h/d/m labels render correctly, which is what exposed this editor bug.

## Changes

- Editor `_valueChanged` for `timer_presets`: replace inline parser with a regex (`^(\\d+)\\s*([smhd])?$`) that mirrors `_parseDurationInputToMs`. Bare numbers stay numeric, suffixed entries preserved as strings.
- Helper hint updated: `Seconds, minutes, hours, or days. e.g. 5, 15, 90s, 2h`.
- `cardVersion` bumped to `2.4.2`.
- Bundle (`simple-timer-card.js`) regenerated.

## Out of scope

`minute_buttons` is not touched. Its consumer `_parseAdjustmentToSeconds` only handles `s`/bare-numbers, so accepting h/d there would require a deeper change.

## Test plan

- Editor: enter `5h, 30s, 2`. YAML should serialize as `[5h, 30s, 2]`. Buttons should render `5h`, `30s`, `2m` and start timers of 5 hours / 30 seconds / 2 minutes respectively.
- Editor: enter only invalid tokens (`abc`). Should fall back to default `[5, 15, 30]`.
- Existing configs with pure-number presets (`[5, 15, 30]`) should round-trip unchanged.