### PR TITLE
feat(adjust): minute_buttons accept s/m/h/d, display uses dd:hh:mm:ss

### DIFF
--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -469,6 +469,8 @@ class SimpleTimerCard extends i$1 {
     this._cardInstanceKey = Math.random().toString(36).slice(2, 10);
     this._editingTimerId = null;
     this._editDuration = { h: 0, m: 0, s: 0 };
+    this._audioUnlocked = false;
+    this._unlockAudioHandler = this._unlockAudio.bind(this);
   }
 
   _isActionThrottled(actionType, timerId = "global", throttleMs = 1000) {
@@ -635,11 +637,13 @@ class SimpleTimerCard extends i$1 {
   connectedCallback() {
     super.connectedCallback();
     this._startTimerUpdates();
+    this.addEventListener("pointerdown", this._unlockAudioHandler, { capture: true, passive: true });
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._stopTimerUpdates();
+    this.removeEventListener("pointerdown", this._unlockAudioHandler, { capture: true });
     for (const timerId of this._activeAudioInstances.keys()) this._stopAudioForTimer(timerId);
     this._activeAudioInstances.clear();
     this._ringingTimers.clear();
@@ -1598,6 +1602,25 @@ class SimpleTimerCard extends i$1 {
     }
   }
 
+  _unlockAudio() {
+    if (this._audioUnlocked) return;
+    // iOS Safari and the HA Companion App webview block audio.play() unless the
+    // page has previously played audio during a user gesture. We play a tiny silent
+    // clip on the first pointerdown so later alarm sounds (which fire from a timer
+    // callback, not a gesture) are allowed by the autoplay policy.
+    this._audioUnlocked = true;
+    try {
+      const a = new Audio("data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA");
+      a.volume = 0;
+      const p = a.play();
+      if (p && typeof p.catch === "function") {
+        p.catch(() => { this._audioUnlocked = false; });
+      }
+    } catch (_) {
+      this._audioUnlocked = false;
+    }
+  }
+
   _playAudioNotification(timerId,timer){
     const entityId = timer?.source_entity || timer?.entity_id || timer?.id || null;
     const entityConf = this._getEntityConfig(entityId);
@@ -1648,7 +1671,9 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
         if (this._ringingTimers.has(timerId) && playCount < maxPlays) {
           playCount++;
           audio.currentTime = 0;
-          audio.play().catch(() => {});
+          audio.play().catch((err) => {
+            console.warn("[simple-timer-card] Alarm audio.play() rejected (likely iOS autoplay policy; tap the card once to unlock):", err?.message || err);
+          });
         } else {
           this._stopAudioForTimer(timerId);
         }

--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -95,6 +95,7 @@ const DAY_IN_SECONDS = 86400;
 const TRANSLATIONS = {
   en: {
     no_timers: "No Timers",
+    timer_name_optional: "Timer Name (Optional)",
     click_to_start: "Click to start",
     no_active_timers: "No Active Timers",
     active_timers: "Active Timers",
@@ -124,6 +125,7 @@ const TRANSLATIONS = {
   },
   de: {
     no_timers: "Keine Timer",
+    timer_name_optional: "Timer-Name (optional)",
     click_to_start: "Zum Starten klicken",
     no_active_timers: "Keine aktiven Timer",
     active_timers: "Aktive Timer",
@@ -153,6 +155,7 @@ const TRANSLATIONS = {
   },
   es: {
     no_timers: "Sin Temporizadores",
+    timer_name_optional: "Nombre del temporizador (opcional)",
     click_to_start: "Clic para iniciar",
     no_active_timers: "Sin Temporizadores Activos",
     active_timers: "Temporizadores Activos",
@@ -182,6 +185,7 @@ const TRANSLATIONS = {
   },
   da: {
     no_timers: "Ingen timere",
+    timer_name_optional: "Timernavn (valgfrit)",
     click_to_start: "Tryk for at starte",
     no_active_timers: "Ingen aktive timere",
     active_timers: "Aktive Timere",
@@ -211,6 +215,7 @@ const TRANSLATIONS = {
   },
   it: {
     no_timers: "Nessun timer",
+    timer_name_optional: "Nome timer (facoltativo)",
     click_to_start: "Clicca per avviare",
     no_active_timers: "Nessun timer attivo",
     active_timers: "Timer attivi",
@@ -240,6 +245,7 @@ const TRANSLATIONS = {
   },
   fr: {
     no_timers: "Aucun minuteur",
+    timer_name_optional: "Nom du minuteur (facultatif)",
     click_to_start: "Cliquez pour démarrer",
     no_active_timers: "Aucun minuteur actif",
     active_timers: "Minuteurs actifs",
@@ -269,6 +275,7 @@ const TRANSLATIONS = {
   },
   he: {
     no_timers: "אין טיימרים",
+    timer_name_optional: "שם הטיימר (אופציונלי)",
     click_to_start: "לחץ להתחלה",
     no_active_timers: "אין טיימרים פעילים",
     active_timers: "טיימרים פעילים",
@@ -298,6 +305,7 @@ const TRANSLATIONS = {
   },
   pl: {
     no_timers: "Brak minutników",
+    timer_name_optional: "Nazwa minutnika (opcjonalnie)",
     click_to_start: "Kliknij, aby uruchomić",
     no_active_timers: "Brak aktywnych minutników",
     active_timers: "Aktywne minutniki",
@@ -327,6 +335,7 @@ const TRANSLATIONS = {
   },
   nl: {
     no_timers: "Geen timers",
+    timer_name_optional: "Timer naam (optioneel)",
     click_to_start: "Klik om te starten",
     no_active_timers: "Geen actieve timers",
     active_timers: "Actieve timers",
@@ -2863,7 +2872,7 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
             ${renderAdjustButtons(-1)}
           </div>
 
-          <input class="text-input" placeholder="Timer Name (Optional)" readonly style="margin-top: 12px;"
+          <input class="text-input" placeholder="${this._localize("timer_name_optional")}" readonly style="margin-top: 12px;"
                  .value=${this._sanitizeText(timerName)} />
 
           <div class="picker-actions">
@@ -3390,7 +3399,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("nt-h-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("nt-h-name", this._localize("timer_name_optional"))}
 
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.noTimerHorizontalOpen = false)}>${this._localize("cancel")}</button>
@@ -3425,7 +3434,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("nt-v-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("nt-v-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.noTimerVerticalOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startFromCustom("vertical")}>${this._localize("start")}</button>
@@ -3465,7 +3474,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("add-fill-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("add-fill-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.activeFillOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startActive("fill")}>${this._localize("start")}</button>
@@ -3501,7 +3510,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("add-bar-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("add-bar-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.activeBarOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startActive("bar")}>${this._localize("start")}</button>

--- a/simple-timer-card.js
+++ b/simple-timer-card.js
@@ -49,7 +49,7 @@ const a=Symbol.for(""),o$1=t=>{if(t?.r===a)return t?._$litStatic$},i=(t,...r)=>(
  */
 
 
-const cardVersion="2.4.2";
+const cardVersion="2.4.3";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -2508,15 +2508,21 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
   }
 
   _parseAdjustmentToSeconds(value) {
-    let seconds = 0;
-    if (typeof value === "string" && value.toLowerCase().endsWith("s")) {
-      const parsedSeconds = parseInt(value.slice(0, -1), 10);
-      if (!isNaN(parsedSeconds)) seconds = parsedSeconds;
-    } else {
-      const parsedMinutes = parseInt(value, 10);
-      if (!isNaN(parsedMinutes)) seconds = parsedMinutes * 60;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value * 60;
     }
-    return seconds;
+    if (typeof value !== "string") return 0;
+    const m = value.trim().toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+    if (!m) return 0;
+    const n = parseInt(m[1], 10);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    switch (m[2]) {
+      case "s": return n;
+      case "h": return n * 3600;
+      case "d": return n * 86400;
+      case "m":
+      default:  return n * 60;
+    }
   }
 
   _adjust(which, value, sign = 1) {
@@ -2851,7 +2857,7 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
             ${renderAdjustButtons(1)}
           </div>
 
-          <div class="display">${this._formatDuration(totalSeconds, "seconds")}</div>
+          <div class="display">${this._formatClock(totalSeconds, true)}</div>
 
           <div class="buttons-grid">
             ${renderAdjustButtons(-1)}
@@ -3380,7 +3386,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), 1)}
           </div>
-          <div class="display">${this._formatDuration(this._customSecs.horizontal, "seconds")}</div>
+          <div class="display">${this._formatClock(this._customSecs.horizontal, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
@@ -3415,7 +3421,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), 1)}
           </div>
-          <div class="display">${this._formatDuration(this._customSecs.vertical, "seconds")}</div>
+          <div class="display">${this._formatClock(this._customSecs.vertical, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
@@ -3455,7 +3461,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), 1)}
           </div>
-          <div class="display">${this._formatDuration(this._activeSecs.fill, "seconds")}</div>
+          <div class="display">${this._formatClock(this._activeSecs.fill, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
@@ -3491,7 +3497,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), 1)}
           </div>
-          <div class="display">${this._formatDuration(this._activeSecs.bar, "seconds")}</div>
+          <div class="display">${this._formatClock(this._activeSecs.bar, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
@@ -3688,13 +3694,11 @@ class SimpleTimerCardEditor extends i$1 {
     }
     if (key === "minute_buttons" && typeof value === "string") {
       value = value.split(",").map(v => v.trim()).filter(v => v).map(v => {
-        if (v.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(v.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-        }
-        const minutes = parseInt(v, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = v.toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter(v => v !== null);
       if (value.length === 0) value = [1, 5, 10];
     }
@@ -3936,16 +3940,14 @@ _pinnedTimerValueChanged(ev, index) {
       const raw = Array.isArray(cleaned.minute_buttons) ? cleaned.minute_buttons : (typeof cleaned.minute_buttons === "string" ? cleaned.minute_buttons.split(",") : []);
       cleaned.minute_buttons = raw.map((v) => {
         if (v === null || v === undefined) return null;
-        const s = String(v).trim();
+        if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+        const s = String(v).trim().toLowerCase();
         if (!s) return null;
-        if (s.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(s.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-          return null;
-        }
-        const minutes = parseInt(s, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = s.match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter((x) => x !== null);
     }
 
@@ -4339,7 +4341,7 @@ _pinnedTimerValueChanged(ev, index) {
         ${this._tf({ label: "Timer name presets", helper: "Comma-separated labels shown in the custom-name picker", value: (this._config.timer_name_presets || []).join(", "), configValue: "timer_name_presets", change: this._valueChanged })}
       ` : ""}
 
-      ${this._tf({ label: "Minute adjustment buttons", helper: "Comma-separated (e.g. 1, 5, 10). Buttons to add/subtract from the custom timer input.", value: (this._config.minute_buttons || [1, 5, 10]).join(", "), configValue: "minute_buttons", change: this._valueChanged })}
+      ${this._tf({ label: "Adjustment buttons", helper: "Seconds, minutes, hours, or days. e.g. 1, 5, 30s, 2h. Default unit is minutes.", value: (this._config.minute_buttons || [1, 5, 10]).join(", "), configValue: "minute_buttons", change: this._valueChanged })}
     `;
 
     const pinnedContent = b`

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -13,7 +13,7 @@ import { html, LitElement, css } from "lit";
 import { html as shtml, literal } from "lit/static-html.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 
-const cardVersion="2.4.2";
+const cardVersion="2.4.3";
 
 const DAY_IN_MS = 86400000;
 const YEAR_IN_MS = 365 * DAY_IN_MS;
@@ -2472,15 +2472,21 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
   }
 
   _parseAdjustmentToSeconds(value) {
-    let seconds = 0;
-    if (typeof value === "string" && value.toLowerCase().endsWith("s")) {
-      const parsedSeconds = parseInt(value.slice(0, -1), 10);
-      if (!isNaN(parsedSeconds)) seconds = parsedSeconds;
-    } else {
-      const parsedMinutes = parseInt(value, 10);
-      if (!isNaN(parsedMinutes)) seconds = parsedMinutes * 60;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value * 60;
     }
-    return seconds;
+    if (typeof value !== "string") return 0;
+    const m = value.trim().toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+    if (!m) return 0;
+    const n = parseInt(m[1], 10);
+    if (!Number.isFinite(n) || n < 0) return 0;
+    switch (m[2]) {
+      case "s": return n;
+      case "h": return n * 3600;
+      case "d": return n * 86400;
+      case "m":
+      default:  return n * 60;
+    }
   }
 
   _adjust(which, value, sign = +1) {
@@ -2815,7 +2821,7 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
             ${renderAdjustButtons(+1)}
           </div>
 
-          <div class="display">${this._formatDuration(totalSeconds, "seconds")}</div>
+          <div class="display">${this._formatClock(totalSeconds, true)}</div>
 
           <div class="buttons-grid">
             ${renderAdjustButtons(-1)}
@@ -3344,7 +3350,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), +1)}
           </div>
-          <div class="display">${this._formatDuration(this._customSecs.horizontal, "seconds")}</div>
+          <div class="display">${this._formatClock(this._customSecs.horizontal, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
@@ -3379,7 +3385,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), +1)}
           </div>
-          <div class="display">${this._formatDuration(this._customSecs.vertical, "seconds")}</div>
+          <div class="display">${this._formatClock(this._customSecs.vertical, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
@@ -3419,7 +3425,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), +1)}
           </div>
-          <div class="display">${this._formatDuration(this._activeSecs.fill, "seconds")}</div>
+          <div class="display">${this._formatClock(this._activeSecs.fill, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
@@ -3455,7 +3461,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), +1)}
           </div>
-          <div class="display">${this._formatDuration(this._activeSecs.bar, "seconds")}</div>
+          <div class="display">${this._formatClock(this._activeSecs.bar, true)}</div>
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
@@ -3652,13 +3658,11 @@ class SimpleTimerCardEditor extends LitElement {
     }
     if (key === "minute_buttons" && typeof value === "string") {
       value = value.split(",").map(v => v.trim()).filter(v => v).map(v => {
-        if (v.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(v.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-        }
-        const minutes = parseInt(v, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = v.toLowerCase().match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter(v => v !== null);
       if (value.length === 0) value = [1, 5, 10];
     }
@@ -3900,16 +3904,14 @@ _pinnedTimerValueChanged(ev, index) {
       const raw = Array.isArray(cleaned.minute_buttons) ? cleaned.minute_buttons : (typeof cleaned.minute_buttons === "string" ? cleaned.minute_buttons.split(",") : []);
       cleaned.minute_buttons = raw.map((v) => {
         if (v === null || v === undefined) return null;
-        const s = String(v).trim();
+        if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+        const s = String(v).trim().toLowerCase();
         if (!s) return null;
-        if (s.toLowerCase().endsWith("s")) {
-          const seconds = parseInt(s.slice(0, -1), 10);
-          if (!isNaN(seconds) && seconds > 0) return `${seconds}s`;
-          return null;
-        }
-        const minutes = parseInt(s, 10);
-        if (!isNaN(minutes) && minutes > 0) return minutes;
-        return null;
+        const m = s.match(/^(\d+)\s*([smhd])?$/);
+        if (!m) return null;
+        const n = parseInt(m[1], 10);
+        if (!Number.isFinite(n) || n <= 0) return null;
+        return m[2] ? `${n}${m[2]}` : n;
       }).filter((x) => x !== null);
     }
 
@@ -4303,7 +4305,7 @@ _pinnedTimerValueChanged(ev, index) {
         ${this._tf({ label: "Timer name presets", helper: "Comma-separated labels shown in the custom-name picker", value: (this._config.timer_name_presets || []).join(", "), configValue: "timer_name_presets", change: this._valueChanged })}
       ` : ""}
 
-      ${this._tf({ label: "Minute adjustment buttons", helper: "Comma-separated (e.g. 1, 5, 10). Buttons to add/subtract from the custom timer input.", value: (this._config.minute_buttons || [1, 5, 10]).join(", "), configValue: "minute_buttons", change: this._valueChanged })}
+      ${this._tf({ label: "Adjustment buttons", helper: "Seconds, minutes, hours, or days. e.g. 1, 5, 30s, 2h. Default unit is minutes.", value: (this._config.minute_buttons || [1, 5, 10]).join(", "), configValue: "minute_buttons", change: this._valueChanged })}
     `;
 
     const pinnedContent = html`

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -59,6 +59,7 @@ const DAY_IN_SECONDS = 86400;
 const TRANSLATIONS = {
   en: {
     no_timers: "No Timers",
+    timer_name_optional: "Timer Name (Optional)",
     click_to_start: "Click to start",
     no_active_timers: "No Active Timers",
     active_timers: "Active Timers",
@@ -88,6 +89,7 @@ const TRANSLATIONS = {
   },
   de: {
     no_timers: "Keine Timer",
+    timer_name_optional: "Timer-Name (optional)",
     click_to_start: "Zum Starten klicken",
     no_active_timers: "Keine aktiven Timer",
     active_timers: "Aktive Timer",
@@ -117,6 +119,7 @@ const TRANSLATIONS = {
   },
   es: {
     no_timers: "Sin Temporizadores",
+    timer_name_optional: "Nombre del temporizador (opcional)",
     click_to_start: "Clic para iniciar",
     no_active_timers: "Sin Temporizadores Activos",
     active_timers: "Temporizadores Activos",
@@ -146,6 +149,7 @@ const TRANSLATIONS = {
   },
   da: {
     no_timers: "Ingen timere",
+    timer_name_optional: "Timernavn (valgfrit)",
     click_to_start: "Tryk for at starte",
     no_active_timers: "Ingen aktive timere",
     active_timers: "Aktive Timere",
@@ -175,6 +179,7 @@ const TRANSLATIONS = {
   },
   it: {
     no_timers: "Nessun timer",
+    timer_name_optional: "Nome timer (facoltativo)",
     click_to_start: "Clicca per avviare",
     no_active_timers: "Nessun timer attivo",
     active_timers: "Timer attivi",
@@ -204,6 +209,7 @@ const TRANSLATIONS = {
   },
   fr: {
     no_timers: "Aucun minuteur",
+    timer_name_optional: "Nom du minuteur (facultatif)",
     click_to_start: "Cliquez pour démarrer",
     no_active_timers: "Aucun minuteur actif",
     active_timers: "Minuteurs actifs",
@@ -233,6 +239,7 @@ const TRANSLATIONS = {
   },
   he: {
     no_timers: "אין טיימרים",
+    timer_name_optional: "שם הטיימר (אופציונלי)",
     click_to_start: "לחץ להתחלה",
     no_active_timers: "אין טיימרים פעילים",
     active_timers: "טיימרים פעילים",
@@ -262,6 +269,7 @@ const TRANSLATIONS = {
   },
   pl: {
     no_timers: "Brak minutników",
+    timer_name_optional: "Nazwa minutnika (opcjonalnie)",
     click_to_start: "Kliknij, aby uruchomić",
     no_active_timers: "Brak aktywnych minutników",
     active_timers: "Aktywne minutniki",
@@ -291,6 +299,7 @@ const TRANSLATIONS = {
   },
   nl: {
     no_timers: "Geen timers",
+    timer_name_optional: "Timer naam (optioneel)",
     click_to_start: "Klik om te starten",
     no_active_timers: "Geen actieve timers",
     active_timers: "Actieve timers",
@@ -2827,7 +2836,7 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
             ${renderAdjustButtons(-1)}
           </div>
 
-          <input class="text-input" placeholder="Timer Name (Optional)" readonly style="margin-top: 12px;"
+          <input class="text-input" placeholder="${this._localize("timer_name_optional")}" readonly style="margin-top: 12px;"
                  .value=${this._sanitizeText(timerName)} />
 
           <div class="picker-actions">
@@ -3354,7 +3363,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("horizontal", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("nt-h-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("nt-h-name", this._localize("timer_name_optional"))}
 
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.noTimerHorizontalOpen = false)}>${this._localize("cancel")}</button>
@@ -3389,7 +3398,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("vertical", (which, m, sign) => this._adjust(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("nt-v-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("nt-v-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.noTimerVerticalOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startFromCustom("vertical")}>${this._localize("start")}</button>
@@ -3429,7 +3438,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("fill", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("add-fill-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("add-fill-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.activeFillOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startActive("fill")}>${this._localize("start")}</button>
@@ -3465,7 +3474,7 @@ const layout = this._config.layout;
           <div class="buttons-grid">
             ${this._renderMinuteButtons("bar", (which, m, sign) => this._adjustActive(which, m, sign), -1)}
           </div>
-          ${this._renderTimerNameSelector("add-bar-name", "Timer Name (Optional)")}
+          ${this._renderTimerNameSelector("add-bar-name", this._localize("timer_name_optional"))}
           <div class="picker-actions">
             <button class="btn btn-ghost" @click=${() => (this._ui.activeBarOpen = false)}>${this._localize("cancel")}</button>
             <button class="btn btn-primary" @click=${() => this._startActive("bar")}>${this._localize("start")}</button>

--- a/src/simple-timer-card.js
+++ b/src/simple-timer-card.js
@@ -433,6 +433,8 @@ class SimpleTimerCard extends LitElement {
     this._cardInstanceKey = Math.random().toString(36).slice(2, 10);
     this._editingTimerId = null;
     this._editDuration = { h: 0, m: 0, s: 0 };
+    this._audioUnlocked = false;
+    this._unlockAudioHandler = this._unlockAudio.bind(this);
   }
 
   _isActionThrottled(actionType, timerId = "global", throttleMs = 1000) {
@@ -599,11 +601,13 @@ class SimpleTimerCard extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this._startTimerUpdates();
+    this.addEventListener("pointerdown", this._unlockAudioHandler, { capture: true, passive: true });
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this._stopTimerUpdates();
+    this.removeEventListener("pointerdown", this._unlockAudioHandler, { capture: true });
     for (const timerId of this._activeAudioInstances.keys()) this._stopAudioForTimer(timerId);
     this._activeAudioInstances.clear();
     this._ringingTimers.clear();
@@ -1562,6 +1566,25 @@ class SimpleTimerCard extends LitElement {
     }
   }
 
+  _unlockAudio() {
+    if (this._audioUnlocked) return;
+    // iOS Safari and the HA Companion App webview block audio.play() unless the
+    // page has previously played audio during a user gesture. We play a tiny silent
+    // clip on the first pointerdown so later alarm sounds (which fire from a timer
+    // callback, not a gesture) are allowed by the autoplay policy.
+    this._audioUnlocked = true;
+    try {
+      const a = new Audio("data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA");
+      a.volume = 0;
+      const p = a.play();
+      if (p && typeof p.catch === "function") {
+        p.catch(() => { this._audioUnlocked = false; });
+      }
+    } catch (_) {
+      this._audioUnlocked = false;
+    }
+  }
+
   _playAudioNotification(timerId,timer){
     const entityId = timer?.source_entity || timer?.entity_id || timer?.id || null;
     const entityConf = this._getEntityConfig(entityId);
@@ -1612,7 +1635,9 @@ if (!audioEnabled || !audioFileUrl || !this._validateAudioUrl(audioFileUrl)) ret
         if (this._ringingTimers.has(timerId) && playCount < maxPlays) {
           playCount++;
           audio.currentTime = 0;
-          audio.play().catch(() => {});
+          audio.play().catch((err) => {
+            console.warn("[simple-timer-card] Alarm audio.play() rejected (likely iOS autoplay policy; tap the card once to unlock):", err?.message || err);
+          });
         } else {
           this._stopAudioForTimer(timerId);
         }


### PR DESCRIPTION
Closes #104.
Closes #106.

## Summary

Bundles two adjacent fixes for the upcoming bigger release:

1. **Adjustment buttons (`minute_buttons`) honor s/m/h/d** — and the duration display next to them uses `dd:hh:mm:ss` so multi-day adjustments render readably.
2. **i18n: localize the "Timer Name (Optional)" placeholder** — was a hard-coded English literal at five sites; now uses `_localize("timer_name_optional")` against all nine locales.

---

## 1. minute_buttons units + display

The +/- adjustment buttons previously only recognized the `s` suffix. `m`/`h`/`d` were silently treated as minutes because `_parseAdjustmentToSeconds` fell through to `parseInt(value) * 60`. The editor's input parser and emit cleanup had the same blind spot. With days now reachable, the duration display next to the buttons also needs to render multi-day durations.

### Behavior

| Entry | Delta |
|---|---|
| `30s` | +30 seconds |
| `5` or `5m` | +5 minutes |
| `2h` | +2 hours |
| `1d` | +1 day |

Bare numbers continue to mean minutes (back-compat with the existing default `[1, 5, 10]`).

### Display format

The five `<div class="display">` duration outputs in the adjust UIs now use `_formatClock(_, true)`:

- days > 0 -> `dd:hh:mm:ss`
- days = 0 -> `hh:mm:ss`
- days + hours = 0 -> `mm:ss`

This matches the existing `time_format: dhms` formatter, so no new code paths.

### Changes

- `_parseAdjustmentToSeconds` rewritten with the same `^(\d+)\s*([smhd])?$` regex used by `_parseDurationInputToMs` and the v2.4.2 timer_presets fix. `s`/`m`/`h`/`d` produce the right delta; bare number = minutes.
- Editor `_valueChanged` (minute_buttons): same regex; suffixed entries preserved as strings in YAML (e.g. `2h`, `1d`).
- Editor emit cleanup (minute_buttons): same.
- Five adjust-UI display sites switched from `_formatDuration(x, "seconds")` to `_formatClock(x, true)`.
- Editor helper text and label updated. Field renamed from `Minute adjustment buttons` to `Adjustment buttons` since the buttons are no longer minute-only.

---

## 2. i18n: "Timer Name (Optional)" placeholder (#106)

Reported by @JosHarink: the placeholder stayed in English even in Dutch. It was a hard-coded literal at five places in `src/simple-timer-card.js`:

- one readonly placeholder in the inline edit overlay for a running timer,
- four `_renderTimerNameSelector(...)` call sites (horizontal/vertical no-timer pickers, fill/bar active pickers).

### Changes

- Added a `timer_name_optional` key to every locale in `TRANSLATIONS`:

  | Locale | Value |
  |---|---|
  | en | `Timer Name (Optional)` |
  | de | `Timer-Name (optional)` |
  | es | `Nombre del temporizador (opcional)` |
  | da | `Timernavn (valgfrit)` |
  | it | `Nome timer (facoltativo)` |
  | fr | `Nom du minuteur (facultatif)` |
  | he | `שם הטיימר (אופציונלי)` |
  | pl | `Nazwa minutnika (opcjonalnie)` |
  | nl | `Timer naam (optioneel)` (provided by @JosHarink in the issue) |

- Replaced each literal with `this._localize("timer_name_optional")`.

---

## Compatibility

- Existing configs with `[1, 5, 10]` keep their behavior (bare numbers = minutes).
- Existing configs with `[30s, 1, 5]` keep their behavior.
- The explicit `m` suffix is now preserved as a string in YAML (was silently coerced to number before). Same semantic value.
- No layout or visual changes outside the duration display and the localized placeholder.

## Test plan

- Editor: set Adjustment buttons to `30s, 5, 1h, 1d`. YAML should serialize as `[30s, 5, 1h, 1d]`. Each button should add the correct delta.
- Custom timer entry: click `1d` -> display reads `01:00:00:00`. Click `1h` -> `01:01:00:00`. Click `30s` -> `01:01:00:30`.
- Switch HA UI language to Dutch -> the timer-name placeholder reads "Timer naam (optioneel)".
- Spot-check at least one other locale (e.g. de or fr).

## Note

Version bump (`cardVersion`) will happen at merge time so the number reflects whatever the final release ends up being (2.4.3, 2.5.0, etc.). Currently the branch still carries `2.4.3` from when this PR was first opened.